### PR TITLE
Allow the frame to be opened and closed while in combat

### DIFF
--- a/xui/dungeon_frame.lua
+++ b/xui/dungeon_frame.lua
@@ -34,7 +34,7 @@ function KeystoneLoot:CreateDungeonFrame(parent)
 	Title:SetJustifyH('LEFT');
 	Title:SetPoint('BOTTOMLEFT', Frame, 'TOPLEFT', 0, 5);
 
-	local TeleportButton = CreateFrame('Button', nil, Frame, 'SecureActionButtonTemplate');
+	local TeleportButton = CreateFrame('Button', nil, Frame, 'InsecureActionButtonTemplate');
 	Frame.TeleportButton = TeleportButton;
 	TeleportButton:Hide();
 	TeleportButton:RegisterForClicks('AnyUp', 'AnyDown');


### PR DESCRIPTION
SecureActionButtonTemplate buttons will block opening and closing the frame in combat, InsecureActionButtonTemplate does not
the insecure version will not allow you to cast the teleport spell while in combat, but then again, who cares about that 🙂 
(see https://warcraft.wiki.gg/wiki/SecureActionButtonTemplate)