### PR TITLE
Add multi-slot loot filtering

### DIFF
--- a/locales/deDE.lua
+++ b/locales/deDE.lua
@@ -6,6 +6,8 @@ end
 
 local L = KeystoneLoot.L;
 
+L["Multiple slot filtering"] = "Mehrere Slots filtern";
+
 -- keystoneloot_frame.lua
 L["%s (%s Season %d)"] = "%s (%s Saison %d)";
 

--- a/locales/enUS.lua
+++ b/locales/enUS.lua
@@ -7,3 +7,4 @@ L["Raid Finder"] = PLAYER_DIFFICULTY3;
 L["Normal"] = PLAYER_DIFFICULTY1;
 L["Heroic"] = PLAYER_DIFFICULTY2;
 L["Mythic"] = PLAYER_DIFFICULTY6;
+L["Multiple slot filtering"] = "Multiple slot filtering";

--- a/locales/esES.lua
+++ b/locales/esES.lua
@@ -6,6 +6,8 @@ end
 
 local L = KeystoneLoot.L;
 
+L["Multiple slot filtering"] = "Filtrado de varios espacios";
+
 -- keystoneloot_frame.lua
 L["%s (%s Season %d)"] = "%s (%s temporada %d)";
 

--- a/locales/frFR.lua
+++ b/locales/frFR.lua
@@ -6,6 +6,8 @@ end
 
 local L = KeystoneLoot.L;
 
+L["Multiple slot filtering"] = "Filtrage de plusieurs emplacements";
+
 -- keystoneloot_frame.lua
 L["%s (%s Season %d)"] = "%s (%s Saison %d)";
 

--- a/locales/itIT.lua
+++ b/locales/itIT.lua
@@ -6,6 +6,8 @@ end
 
 local L = KeystoneLoot.L;
 
+L["Multiple slot filtering"] = "Filtro slot multipli";
+
 -- keystoneloot_frame.lua
 L["%s (%s Season %d)"] = "%s (%s Stagione %d)";
 

--- a/locales/koKR.lua
+++ b/locales/koKR.lua
@@ -6,6 +6,8 @@ end
 
 local L = KeystoneLoot.L;
 
+L["Multiple slot filtering"] = "Multiple slot filtering";
+
 -- keystoneloot_frame.lua
 L["%s (%s Season %d)"] = "%s (%s 시즌 %d)";
 

--- a/locales/ptBR.lua
+++ b/locales/ptBR.lua
@@ -6,6 +6,8 @@ end
 
 local L = KeystoneLoot.L;
 
+L["Multiple slot filtering"] = "Filtro de varios espacos";
+
 -- keystoneloot_frame.lua
 L["%s (%s Season %d)"] = "%s (%s Série %d)";
 

--- a/locales/ruRU.lua
+++ b/locales/ruRU.lua
@@ -6,6 +6,8 @@ end
 
 local L = KeystoneLoot.L;
 
+L["Multiple slot filtering"] = "Multiple slot filtering";
+
 -- keystoneloot_frame.lua
 L["%s (%s Season %d)"] = "%s (%s сезон %d)";
 

--- a/locales/zhCN.lua
+++ b/locales/zhCN.lua
@@ -6,6 +6,8 @@ end
 
 local L = KeystoneLoot.L;
 
+L["Multiple slot filtering"] = "Multiple slot filtering";
+
 -- keystoneloot_frame.lua
 L["%s (%s Season %d)"] = "%s（%s 第 %d 赛季）";
 

--- a/locales/zhTW.lua
+++ b/locales/zhTW.lua
@@ -6,6 +6,8 @@ end
 
 local L = KeystoneLoot.L;
 
+L["Multiple slot filtering"] = "Multiple slot filtering";
+
 -- keystoneloot_frame.lua
 L["%s (%s Season %d)"] = "%s（%s 第 %d 賽季）";
 

--- a/modules/db.lua
+++ b/modules/db.lua
@@ -6,7 +6,7 @@ local DB = KeystoneLoot.DB;
 
 local CURRENT_SEASON = KeystoneLoot.Config.season;
 
-local DB_VERSION = 7;
+local DB_VERSION = 8;
 local CHAR_DB_VERSION = 2;
 
 local observers = {};
@@ -77,7 +77,8 @@ function DB:MigrateGlobalDB(fromVersion)
                 versatility = true,
                 noStats = true
             },
-            keystoneTooltip = true
+            keystoneTooltip = true,
+            multiSlotFilter = false
         };
 
         KeystoneLootDB.favorites = {};
@@ -106,6 +107,10 @@ function DB:MigrateGlobalDB(fromVersion)
     if (fromVersion == 6) then
         KeystoneLootDB.settings.lootReminder.dropAlert = true;
         KeystoneLootDB.settings.lootReminder.whisperMessage = "Can I have {item} please?";
+    end
+
+    if (fromVersion == 7) then
+        KeystoneLootDB.settings.multiSlotFilter = false;
     end
 end
 

--- a/modules/query.lua
+++ b/modules/query.lua
@@ -91,12 +91,43 @@ local function GetFavoritesListSpecId()
     return 0;
 end
 
+local function GetSlotFilter()
+    local slotId = DB:Get("filters.slotId");
+
+    if (slotId == -1 or slotId == -2) then
+        return slotId;
+    end
+
+    local slotIds = DB:Get("filters.slotIds");
+    if (type(slotIds) == "table") then
+        for _, selected in pairs(slotIds) do
+            if (selected) then
+                return nil, slotIds;
+            end
+        end
+    end
+
+    return slotId;
+end
+
+local function ItemMatchesSlot(item, slotId, slotIds, hideOtherItems)
+    if (slotId == -2) then
+        return not (hideOtherItems and item.slotId == 14);
+    end
+
+    if (slotIds) then
+        return slotIds[item.slotId] == true;
+    end
+
+    return item.slotId == slotId;
+end
+
 function Query:GetDungeons()
     return KeystoneLoot.DungeonDatabase;
 end
 
 function Query:GetDungeonItems(challengeModeId)
-    local slotId = DB:Get("filters.slotId");
+    local slotId, slotIds = GetSlotFilter();
 
     -- Favorites slot
     if (slotId == -1) then
@@ -115,8 +146,7 @@ function Query:GetDungeonItems(challengeModeId)
             for _, itemId in ipairs(dungeon.lootTable) do
                 local item = self:GetItemInfo(itemId);
 
-                if (item and (slotId == -2 or item.slotId == slotId) and item.classes[classId]
-                        and not (slotId == -2 and hideOtherItems and item.slotId == 14)) then
+                if (item and ItemMatchesSlot(item, slotId, slotIds, hideOtherItems) and item.classes[classId]) then
                     if (specId == 0) then
                         table.insert(results, { itemId = itemId, icon = item.icon });
                     else
@@ -172,7 +202,7 @@ function Query:GetRaids()
 end
 
 function Query:GetRaidItems(bossId)
-    local slotId = DB:Get("filters.slotId");
+    local slotId, slotIds = GetSlotFilter();
 
     -- Favorites slot
     if (slotId == -1) then
@@ -195,8 +225,7 @@ function Query:GetRaidItems(bossId)
                 for _, itemId in ipairs(loot) do
                     local item = self:GetItemInfo(itemId)
 
-                    if (item and (slotId == -2 or item.slotId == slotId) and item.classes[classId]
-                            and not (slotId == -2 and hideOtherItems and item.slotId == 14)) then
+                    if (item and ItemMatchesSlot(item, slotId, slotIds, hideOtherItems) and item.classes[classId]) then
                         if (specId == 0) then
                             table.insert(results, { itemId = itemId, icon = item.icon });
                         else
@@ -259,7 +288,7 @@ end
 
 function Query:GetCatalystItems()
     local classId = DB:Get("filters.classId");
-    local slotId = DB:Get("filters.slotId");
+    local slotId, slotIds = GetSlotFilter();
 
     -- Favorites slot
     if (slotId == -1) then
@@ -271,7 +300,7 @@ function Query:GetCatalystItems()
     local results = {};
 
     for itemId, item in pairs(KeystoneLoot.CatalystDatabase) do
-        if (item.classId == classId and (slotId == -2 or item.slotId == slotId)) then
+        if (item.classId == classId and ItemMatchesSlot(item, slotId, slotIds)) then
             table.insert(results, {
                 itemId = itemId,
                 icon = item.icon

--- a/modules/query.lua
+++ b/modules/query.lua
@@ -99,7 +99,7 @@ local function GetSlotFilter()
     end
 
     local slotIds = DB:Get("filters.slotIds");
-    if (type(slotIds) == "table") then
+    if (DB:Get("settings.multiSlotFilter") and type(slotIds) == "table") then
         for _, selected in pairs(slotIds) do
             if (selected) then
                 return nil, slotIds;

--- a/ui/keystoneloot_frame/mixins/settings_dropdown.lua
+++ b/ui/keystoneloot_frame/mixins/settings_dropdown.lua
@@ -190,6 +190,11 @@ function KeystoneLootSettingsDropdownMixin:Init()
             function() DB:Set("settings.hideOtherItems", not DB:Get("settings.hideOtherItems")); end
         );
         rootDescription:CreateCheckbox(
+            L["Multiple slot filtering"],
+            function() return DB:Get("settings.multiSlotFilter"); end,
+            function() DB:Set("settings.multiSlotFilter", not DB:Get("settings.multiSlotFilter")); end
+        );
+        rootDescription:CreateCheckbox(
             L["Wide mode"],
             function() return DB:Get("settings.wideMode"); end,
             function() DB:Set("settings.wideMode", not DB:Get("settings.wideMode")); end

--- a/ui/keystoneloot_frame/mixins/slot_dropdown.lua
+++ b/ui/keystoneloot_frame/mixins/slot_dropdown.lua
@@ -23,43 +23,129 @@ local SLOTS = {
 
 KeystoneLootSlotDropdownMixin = {};
 
+local function GetSelectedSlots()
+    local slotId = DB:Get("filters.slotId");
+    if (slotId == -1 or slotId == -2) then
+        return {};
+    end
+
+    local selectedSlots = DB:Get("filters.slotIds");
+
+    if (type(selectedSlots) == "table") then
+        return selectedSlots;
+    end
+
+    if (slotId and slotId >= 0) then
+        return { [slotId] = true };
+    end
+
+    return {};
+end
+
+local function HasSelectedSlot(selectedSlots)
+    for _, selected in pairs(selectedSlots) do
+        if (selected) then
+            return true;
+        end
+    end
+
+    return false;
+end
+
+local function GetFirstSelectedSlot(selectedSlots)
+    local firstSlotId;
+
+    for slotId, selected in pairs(selectedSlots) do
+        if (selected and (not firstSlotId or slotId < firstSlotId)) then
+            firstSlotId = slotId;
+        end
+    end
+
+    return firstSlotId;
+end
+
+local function GetSelectedSlotCount(selectedSlots)
+    local count = 0;
+
+    for _, selected in pairs(selectedSlots) do
+        if (selected) then
+            count = count + 1;
+        end
+    end
+
+    return count;
+end
+
 function KeystoneLootSlotDropdownMixin:Init()
     self:SetSelectionText(function(selections)
-        if (#selections == 0) then
+        local slotId = DB:Get("filters.slotId");
+
+        if (slotId == -1) then
             return FAVORITES;
         end
 
-        local data = selections[1].data;
-        if (not data) then
-            return FAVORITES;
+        if (slotId == -2) then
+            return ALL_INVENTORY_SLOTS;
         end
 
-        return data.name;
+        local selectedSlots = GetSelectedSlots();
+        local count = GetSelectedSlotCount(selectedSlots);
+        local firstSlotId = GetFirstSelectedSlot(selectedSlots);
+
+        if (count == 0 or not firstSlotId) then
+            return ALL_INVENTORY_SLOTS;
+        end
+
+        local firstSlotName = SLOTS[firstSlotId + 1];
+        if (count == 1) then
+            return firstSlotName;
+        end
+
+        return string.format("%s + %d", firstSlotName, count - 1);
     end);
 
     self:SetupMenu(function(dropdown, rootDescription)
         rootDescription:SetTag("MENU_KEYSTONELOOT_SLOT_DROPDOWN");
 
-        local function IsSelected(data)
+        local function IsSpecialSelected(data)
             return DB:Get("filters.slotId") == data.slotId;
         end
 
-        local function SetSelected(data)
+        local function SetSpecialSelected(data)
+            DB:Set("filters.slotIds", {});
             DB:Set("filters.slotId", data.slotId);
         end
 
-        rootDescription:CreateRadio(FAVORITES, IsSelected, SetSelected, { slotId = -1 });
+        local function IsSlotSelected(data)
+            local selectedSlots = GetSelectedSlots();
+            return selectedSlots[data.slotId];
+        end
+
+        local function ToggleSlot(data)
+            local selectedSlots = CopyTable(GetSelectedSlots());
+            selectedSlots[data.slotId] = not selectedSlots[data.slotId] or nil;
+
+            if (HasSelectedSlot(selectedSlots)) then
+                DB:Set("filters.slotIds", selectedSlots);
+                DB:Set("filters.slotId", GetFirstSelectedSlot(selectedSlots));
+            else
+                DB:Set("filters.slotIds", {});
+                DB:Set("filters.slotId", -2);
+            end
+        end
+
+        rootDescription:CreateRadio(FAVORITES, IsSpecialSelected, SetSpecialSelected, { slotId = -1 });
         rootDescription:CreateDivider();
-        rootDescription:CreateRadio(ALL_INVENTORY_SLOTS, IsSelected, SetSelected, { slotId = -2 });
+        rootDescription:CreateRadio(ALL_INVENTORY_SLOTS, IsSpecialSelected, SetSpecialSelected, { slotId = -2 });
 
         for index, slotName in ipairs(SLOTS) do
             local slotId = index - 1; -- 0-based
-            local radio = rootDescription:CreateRadio(slotName, IsSelected, SetSelected, { slotId = slotId });
+            local checkbox = rootDescription:CreateCheckbox(slotName, IsSlotSelected, ToggleSlot, { slotId = slotId });
 
             if (not self:SlotHasItems(slotId)) then
-                radio:SetEnabled(false);
+                checkbox:SetEnabled(false);
 
-                radio:SetTooltip(function(tooltip, elementDescription)
+                checkbox:SetTooltip(function(tooltip, elementDescription)
                     GameTooltip_AddColoredLine(tooltip, BROWSE_NO_RESULTS, RED_FONT_COLOR);
                 end);
             end
@@ -70,12 +156,22 @@ function KeystoneLootSlotDropdownMixin:Init()
         -- Check if current slot still has items
         local currentSlot = DB:Get("filters.slotId");
 
-        -- Skip favorites slot
+        -- Skip favorites and all-slots modes
         if (currentSlot ~= -1 and currentSlot ~= -2) then
-            local hasItems = self:SlotHasItems(currentSlot);
+            local selectedSlots = CopyTable(GetSelectedSlots());
 
-            -- If current slot is now empty, reset to Head
-            if (not hasItems) then
+            for slotId, selected in pairs(selectedSlots) do
+                if (selected and not self:SlotHasItems(slotId)) then
+                    selectedSlots[slotId] = nil;
+                end
+            end
+
+            -- If selected slots are now empty, reset to all slots.
+            if (HasSelectedSlot(selectedSlots)) then
+                DB:Set("filters.slotIds", selectedSlots);
+                DB:Set("filters.slotId", GetFirstSelectedSlot(selectedSlots));
+            else
+                DB:Set("filters.slotIds", {});
                 DB:Set("filters.slotId", -2);
             end
         end
@@ -85,6 +181,7 @@ function KeystoneLootSlotDropdownMixin:Init()
 
     DB:AddObserver("ui.selectedTab", OnChanged);
     DB:AddObserver("ui.selectedRaidTab", OnChanged);
+    DB:AddObserver("filters.classId", OnChanged);
     DB:AddObserver("filters.specId", OnChanged);
 end
 

--- a/ui/keystoneloot_frame/mixins/slot_dropdown.lua
+++ b/ui/keystoneloot_frame/mixins/slot_dropdown.lua
@@ -25,14 +25,18 @@ KeystoneLootSlotDropdownMixin = {};
 
 local function GetSelectedSlots()
     local slotId = DB:Get("filters.slotId");
-    if (slotId == -1 or slotId == -2) then
+    if (not DB:Get("settings.multiSlotFilter") or slotId == -1 or slotId == -2) then
         return {};
     end
 
     local selectedSlots = DB:Get("filters.slotIds");
 
     if (type(selectedSlots) == "table") then
-        return selectedSlots;
+        for _, selected in pairs(selectedSlots) do
+            if (selected) then
+                return selectedSlots;
+            end
+        end
     end
 
     if (slotId and slotId >= 0) then
@@ -88,6 +92,10 @@ function KeystoneLootSlotDropdownMixin:Init()
             return ALL_INVENTORY_SLOTS;
         end
 
+        if (not DB:Get("settings.multiSlotFilter")) then
+            return SLOTS[slotId + 1];
+        end
+
         local selectedSlots = GetSelectedSlots();
         local count = GetSelectedSlotCount(selectedSlots);
         local firstSlotId = GetFirstSelectedSlot(selectedSlots);
@@ -116,7 +124,16 @@ function KeystoneLootSlotDropdownMixin:Init()
             DB:Set("filters.slotId", data.slotId);
         end
 
+        local function SetSlotSelected(data)
+            DB:Set("filters.slotIds", {});
+            DB:Set("filters.slotId", data.slotId);
+        end
+
         local function IsSlotSelected(data)
+            if (not DB:Get("settings.multiSlotFilter")) then
+                return DB:Get("filters.slotId") == data.slotId;
+            end
+
             local selectedSlots = GetSelectedSlots();
             return selectedSlots[data.slotId];
         end
@@ -140,7 +157,12 @@ function KeystoneLootSlotDropdownMixin:Init()
 
         for index, slotName in ipairs(SLOTS) do
             local slotId = index - 1; -- 0-based
-            local checkbox = rootDescription:CreateCheckbox(slotName, IsSlotSelected, ToggleSlot, { slotId = slotId });
+            local checkbox;
+            if (DB:Get("settings.multiSlotFilter")) then
+                checkbox = rootDescription:CreateCheckbox(slotName, IsSlotSelected, ToggleSlot, { slotId = slotId });
+            else
+                checkbox = rootDescription:CreateRadio(slotName, IsSlotSelected, SetSlotSelected, { slotId = slotId });
+            end
 
             if (not self:SlotHasItems(slotId)) then
                 checkbox:SetEnabled(false);
@@ -158,6 +180,17 @@ function KeystoneLootSlotDropdownMixin:Init()
 
         -- Skip favorites and all-slots modes
         if (currentSlot ~= -1 and currentSlot ~= -2) then
+            if (not DB:Get("settings.multiSlotFilter")) then
+                DB:Set("filters.slotIds", {});
+
+                if (not self:SlotHasItems(currentSlot)) then
+                    DB:Set("filters.slotId", -2);
+                end
+
+                self:GenerateMenu();
+                return;
+            end
+
             local selectedSlots = CopyTable(GetSelectedSlots());
 
             for slotId, selected in pairs(selectedSlots) do
@@ -183,6 +216,7 @@ function KeystoneLootSlotDropdownMixin:Init()
     DB:AddObserver("ui.selectedRaidTab", OnChanged);
     DB:AddObserver("filters.classId", OnChanged);
     DB:AddObserver("filters.specId", OnChanged);
+    DB:AddObserver("settings.multiSlotFilter", OnChanged);
 end
 
 function KeystoneLootSlotDropdownMixin:SlotHasItems(slotId)


### PR DESCRIPTION
## Summary
- add an optional multiple-slot filter mode, disabled by default
- preserve existing single-slot, All Slots, and Favorites behavior

## Screenshots 
<img width="440" height="461" alt="1" src="https://github.com/user-attachments/assets/30de7450-5e00-4751-9f26-a3e84a0c4757" />
<img width="613" height="466" alt="multi_select1" src="https://github.com/user-attachments/assets/04498c37-3aa8-4cba-a47e-0e5821d3ae99" />
<img width="455" height="482" alt="multi_select2" src="https://github.com/user-attachments/assets/8c045e29-7540-4f3e-861d-7892c85ca77d" />
<img width="617" height="428" alt="multi_select4" src="https://github.com/user-attachments/assets/e2c90de2-df20-4e99-87c8-66b70913c1dc" />
<img width="609" height="427" alt="multi_select5" src="https://github.com/user-attachments/assets/726f7916-24a4-426d-af3d-b5cc439eac39" />


