### PR TITLE
Fix Blizzard DamageMeter taint from XML frame instantiation

### DIFF
--- a/KeystoneLoot.toc
+++ b/KeystoneLoot.toc
@@ -118,3 +118,5 @@ ui/keystoneloot_frame/mixins/character_dropdown.lua
 ui/keystoneloot_frame/mixins/settings_dropdown.lua
 ui/keystoneloot_frame/mixins/keystoneloot_frame.lua
 ui/keystoneloot_frame/keystoneloot_frame.xml
+
+ui/bootstrap.lua

--- a/ui/bootstrap.lua
+++ b/ui/bootstrap.lua
@@ -1,0 +1,7 @@
+-- Instantiating addon-owned frames directly from XML taints the retail 12.0.7
+-- Blizzard_DamageMeter secret-value execution path. Keep XML definitions
+-- virtual and create the four runtime frames from Lua instead.
+CreateFrame("Frame", "KeystoneLootFrame", UIParent, "KeystoneLootFrameTemplate");
+CreateFrame("Button", "KeystoneLootMinimapButton", Minimap, "KeystoneLootMinimapButtonTemplate");
+CreateFrame("Frame", "KeystoneLootReminderFrame", UIParent, "KeystoneLootReminderFrameTemplate");
+CreateFrame("Frame", "KeystoneLootDropNotificationFrame", UIParent, "KeystoneLootDropNotificationFrameTemplate");

--- a/ui/drop_notification_frame/drop_notification_frame.xml
+++ b/ui/drop_notification_frame/drop_notification_frame.xml
@@ -94,7 +94,7 @@
         </Scripts>
     </Button>
 
-    <Frame name="KeystoneLootDropNotificationFrame" parent="UIParent" mixin="KeystoneLootDropNotificationFrameMixin" inherits="SimplePanelTemplate" frameStrata="DIALOG" toplevel="true" movable="true" enableMouse="true" clampedToScreen="true" hidden="true">
+    <Frame name="KeystoneLootDropNotificationFrameTemplate" mixin="KeystoneLootDropNotificationFrameMixin" inherits="SimplePanelTemplate" frameStrata="DIALOG" toplevel="true" movable="true" enableMouse="true" clampedToScreen="true" hidden="true" virtual="true">
         <Size x="280" y="150"/>
         <Anchors>
             <Anchor point="CENTER" y="150"/>

--- a/ui/keystoneloot_frame/keystoneloot_frame.xml
+++ b/ui/keystoneloot_frame/keystoneloot_frame.xml
@@ -29,7 +29,7 @@
         </Scripts>
     </DropdownButton>
 
-    <Frame name="KeystoneLootFrame" parent="UIParent" inherits="ButtonFrameBaseTemplate, TabSystemOwnerTemplate, CallbackRegistrantTemplate" toplevel="true" movable="true" enableMouse="true" clampedToScreen="true" hidden="true" mixin="KeystoneLootFrameMixin">
+    <Frame name="KeystoneLootFrameTemplate" inherits="ButtonFrameBaseTemplate, TabSystemOwnerTemplate, CallbackRegistrantTemplate" toplevel="true" movable="true" enableMouse="true" clampedToScreen="true" hidden="true" mixin="KeystoneLootFrameMixin" virtual="true">
         <Anchors>
             <Anchor point="CENTER"/>
         </Anchors>

--- a/ui/loot_reminder_frame/loot_reminder_frame.xml
+++ b/ui/loot_reminder_frame/loot_reminder_frame.xml
@@ -74,7 +74,7 @@
         </Scripts>
     </Frame>
 
-    <Frame name="KeystoneLootReminderFrame" parent="UIParent" mixin="KeystoneLootReminderFrameMixin" inherits="SimplePanelTemplate" frameStrata="DIALOG" toplevel="true" movable="true" enableMouse="true" clampedToScreen="true" hidden="true">
+    <Frame name="KeystoneLootReminderFrameTemplate" mixin="KeystoneLootReminderFrameMixin" inherits="SimplePanelTemplate" frameStrata="DIALOG" toplevel="true" movable="true" enableMouse="true" clampedToScreen="true" hidden="true" virtual="true">
         <Size x="400" y="217"/>
         <Anchors>
             <Anchor point="CENTER" y="150"/>

--- a/ui/minimap_button/minimap_button.xml
+++ b/ui/minimap_button/minimap_button.xml
@@ -1,5 +1,5 @@
 <Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/ ..\..\..\..\..\WoW\Data\Interface\AddOns\Blizzard_SharedXML\UI.xsd">
-    <Button name="KeystoneLootMinimapButton" parent="Minimap" mixin="KeystoneLootMinimapButtonMixin" frameStrata="MEDIUM" frameLevel="8" hidden="true">
+    <Button name="KeystoneLootMinimapButtonTemplate" mixin="KeystoneLootMinimapButtonMixin" frameStrata="MEDIUM" frameLevel="8" hidden="true" virtual="true">
         <Size x="31" y="31"/>
         <Layers>
             <Layer level="ARTWORK" textureSubLevel="1">


### PR DESCRIPTION
## Summary

- convert KeystoneLoot's four load-time runtime XML frames into virtual templates
- instantiate those templates from Lua after all XML definitions have loaded
- preserve the original global frame names, parents, mixins, inherited templates, and behavior

## Problem

On WoW Retail 12.0.7, enabling KeystoneLoot can make Blizzard's native Damage Meter fail when it handles secret combat-session values. The observed errors include:

```text
Blizzard_DamageMeter/DamageMeterEntry.lua:87:
attempt to compare field 'sourceDisplayType'
(a secret number value, while execution tainted by 'KeystoneLoot')

Blizzard_DamageMeter/DamageMeterSessionWindow.lua:930:
attempt to compare local 'durationSeconds'
(a secret number value, while execution tainted by 'KeystoneLoot')
```

The visible stack is entirely inside Blizzard's Damage Meter because that is where the tainted execution finally attempts to compare a secret value. Disabling KeystoneLoot prevents the errors.

## Isolation and root cause boundary

The issue was reduced with controlled load tests:

1. Loading KeystoneLoot's configuration, data, database, character, and query modules did not reproduce the taint.
2. Loading the UI Lua mixins and virtual menu templates without creating runtime frames did not reproduce it.
3. Instantiating a single anonymous, hidden 1x1 `Frame` directly from addon XML reproduced the Damage Meter taint. The probe had no name, parent declaration, mixin, scripts, events, hooks, or child controls.
4. Creating the equivalent anonymous hidden frame from Lua with `CreateFrame` did not reproduce it.

This makes load-time XML frame instantiation the minimal observable trigger. The underlying propagation appears to be a Retail 12.0.7 engine interaction between addon XML loading, taint tracking, and Damage Meter's secret values; the engine-internal propagation mechanism is not observable from addon code.

## Fix

The four XML objects that previously instantiated runtime frames at file-load time are now virtual templates:

- `KeystoneLootFrameTemplate`
- `KeystoneLootMinimapButtonTemplate`
- `KeystoneLootReminderFrameTemplate`
- `KeystoneLootDropNotificationFrameTemplate`

`ui/bootstrap.lua`, loaded after every mixin and XML template, creates the runtime frames through `CreateFrame`. It uses the existing runtime names and parents, so current global references, `UISpecialFrames`, slash commands, minimap behavior, reminders, notifications, and the public API continue to work without business-logic changes.

## Validation

- reproduced the original Damage Meter errors repeatedly on Retail 12.0.7
- verified that the Lua-instantiated-frame workaround removes the KeystoneLoot-attributed Damage Meter errors while the addon UI remains functional
- parsed every TOC-loaded XML file and confirmed that no top-level runtime XML object remains non-virtual
- confirmed every TOC path exists and `ui/bootstrap.lua` loads after all templates
- `git diff --check` passes

There is no automated WoW runtime test suite in the repository, so the in-game validation was manual.
